### PR TITLE
add lv2 project as sub-module and use headers from there by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,9 +21,6 @@ jobs:
       with:
         submodules: recursive
 
-    - name: Install Dependencies
-      run: brew install lv2
-
     - name: Set Archive Name
       run: echo "ARCHIVE_NAME=Aether-macos.tar.xz" >> "$GITHUB_ENV"
 
@@ -58,15 +55,20 @@ jobs:
 
     strategy:
       matrix:
-        compiler: [g++-10, clang++-10]
-
+        config:
+          - { compiler: GNU,  CC: gcc-10,   CXX: g++-10 }
+          - { compiler: LLVM, CC: clang-10, CXX: clang++-10 }
+          
     steps:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
 
+    - name: Update APT Lists
+      run: sudo apt-get update
+      
     - name: Install Dependencies
-      run: sudo apt install lv2-dev libgl1-mesa-dev libglu1-mesa-dev
+      run: sudo apt-get install libgl1-mesa-dev libglu1-mesa-dev
 
     - name: Set Archive Name
       run: echo "ARCHIVE_NAME=Aether-${{ matrix.compiler }}.tar.xz" >> "$GITHUB_ENV"
@@ -77,7 +79,8 @@ jobs:
     - name: Build Plugin
       working-directory: ${{github.workspace}}/build
       env:
-        CXX: ${{ matrix.compiler }}
+        CC: ${{ matrix.config.CC }}
+        CXX: ${{ matrix.config.CXX }}
       run: |
         cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_TESTS="on"
         cmake --build . --config $BUILD_TYPE
@@ -105,9 +108,6 @@ jobs:
       with:
         submodules: recursive
 
-    - name: Install Dependencies
-      run: git clone https://gitlab.com/lv2/lv2.git
-
     - name: Set Archive Name
       run: echo "ARCHIVE_NAME=Aether-windows.zip" >> "$GITHUB_ENV"
 
@@ -116,7 +116,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -G "Visual Studio 16 2019" .. -DLV2_INCLUDE_PATH="lv2"
+        cmake -G "Visual Studio 16 2019" ..
         cmake --build . --config=release
 
     - name: Create Archive

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
       run: sudo apt-get install libgl1-mesa-dev libglu1-mesa-dev
 
     - name: Set Archive Name
-      run: echo "ARCHIVE_NAME=Aether-${{ matrix.compiler }}.tar.xz" >> "$GITHUB_ENV"
+      run: echo "ARCHIVE_NAME=Aether-${{ matrix.config.compiler }}.tar.xz" >> "$GITHUB_ENV"
 
     - name: Create Build Environment
       run: cmake -E make_directory ${{github.workspace}}/build

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "extern/benchmark"]
 	path = extern/benchmark
 	url = https://github.com/google/benchmark.git
+[submodule "extern/lv2"]
+	path = extern/lv2
+	url = https://github.com/lv2/lv2.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,9 @@ endif()
 if (DEFINED LV2_INCLUDE_PATH)
 	target_include_directories(aether_dsp SYSTEM PRIVATE ${LV2_INCLUDE_PATH})
 	target_include_directories(aether_ui SYSTEM PRIVATE ${LV2_INCLUDE_PATH})
+else()
+	target_include_directories(aether_dsp SYSTEM PRIVATE extern/lv2)
+	target_include_directories(aether_ui SYSTEM PRIVATE extern/lv2)
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,12 +21,7 @@ else()
 endif()
 
 
-if (DEFINED LV2_INCLUDE_PATH)
-	target_include_directories(aether_dsp SYSTEM PRIVATE ${LV2_INCLUDE_PATH})
-	target_include_directories(aether_ui SYSTEM PRIVATE ${LV2_INCLUDE_PATH})
-else()
-	include_directories(extern/lv2)
-endif()
+include_directories(SYSTEM extern/lv2)
 
 
 add_subdirectory(src/DSP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,21 +21,20 @@ else()
 endif()
 
 
+if (DEFINED LV2_INCLUDE_PATH)
+	target_include_directories(aether_dsp SYSTEM PRIVATE ${LV2_INCLUDE_PATH})
+	target_include_directories(aether_ui SYSTEM PRIVATE ${LV2_INCLUDE_PATH})
+else()
+	include_directories(extern/lv2)
+endif()
+
+
 add_subdirectory(src/DSP)
 
 option(BUILD_GUI "Build user interface" ON)
 
 if (BUILD_GUI)
 	add_subdirectory(src/UI)
-endif()
-
-
-if (DEFINED LV2_INCLUDE_PATH)
-	target_include_directories(aether_dsp SYSTEM PRIVATE ${LV2_INCLUDE_PATH})
-	target_include_directories(aether_ui SYSTEM PRIVATE ${LV2_INCLUDE_PATH})
-else()
-	target_include_directories(aether_dsp SYSTEM PRIVATE extern/lv2)
-	target_include_directories(aether_ui SYSTEM PRIVATE extern/lv2)
 endif()
 
 

--- a/README.md
+++ b/README.md
@@ -45,25 +45,21 @@ Binaries from the latest release can be found under [releases](https://github.co
 
 | Library | Deb Package  |
 | ------- | ------------ |
-| Lv2     | `lv2-dev`    |
 | X11     | `libx11-dev` |
 | OpenGL  | `libgl1-mesa-dev` `libglu1-mesa-dev` |
 
 **Ubuntu/Debian**
 ```bash
-sudo apt install cmake g++-10 lv2-dev libx11-dev libgl1-mesa-dev libglu1-mesa-dev
+sudo apt install cmake g++-10 libx11-dev libgl1-mesa-dev libglu1-mesa-dev
 ```
 
 **MacOS**
-```bash
-brew install cmake lv2
-```
+* Should work as it is.
 
 **Windows**
 * Install Visual Studio Community from: https://visualstudio.microsoft.com/vs/community/
 * Install CMake from: https://cmake.org/download/
 * Install Git from: https://git-scm.com/download/win
-* LV2 development files can be used without installation by cloning https://gitlab.com/lv2/lv2.git and passing `-DLV2_INCLUDE_PATH="path/to/lv2"` to cmake.
 
 ### Compiling
 
@@ -85,7 +81,7 @@ make -j4
 
 **Windows**
 ```bash
-cmake -G "Visual Studio 16 2019" .. # -DLV2_INCLUDE_PATH="path/to/lv2"
+cmake -G "Visual Studio 16 2019" ..
 cmake --build . --config=release -j4
 ```
 
@@ -97,7 +93,6 @@ cmake --build . --config=release -j4
 | BUILD_TESTS | Build unit tests. The tests can be run using `make test` and individual tests can be found in `builds/tests/tests`. | `on` / `off` |
 | BUILD_BENCHMARKS | Build benchmarks. The benchmarks can be run using `make test` and individual benchmarks can be found in `builds/tests/benchmarks`. | `on` / `off` |
 | CMAKE_BUILD_TYPE | Debug adds runtime checks and debug information. Release enables additional optimizations. Can also be set using the `--config` flag when running cmake.  | `debug` / `release` |
-| LV2_INCLUDE_PATH | Path to lv2 install location. Used when the lv2 development files are installed to a custom location.  | `path/to/lv2` |
 
 ### Installing
 

--- a/src/UI/CMakeLists.txt
+++ b/src/UI/CMakeLists.txt
@@ -14,9 +14,15 @@ target_compile_features(aether_ui PUBLIC cxx_std_20)
 set_target_properties(aether_ui
 	PROPERTIES
 	CXX_VISIBILITY_PRESET hidden
-	INTERPROCEDURAL_OPTIMIZATION TRUE
 	PREFIX ""
 )
+
+if("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+	set_target_properties(aether_ui
+		PROPERTIES
+		INTERPROCEDURAL_OPTIMIZATION TRUE
+	)
+endif()
 
 # Dependencies
 
@@ -47,7 +53,7 @@ else()
 	target_compile_options(aether_ui PRIVATE
 		-Wall -Wextra -Wpedantic -Wshadow -Wstrict-aliasing
 		-Wunreachable-code -Wdouble-promotion
-		"$<$<CONFIG:DEBUG>:-Og;-ggdb;-Werror>"
+		"$<$<CONFIG:DEBUG>:-O2;-g;-Werror>"
 		"$<$<CONFIG:RELEASE>:-O3>"
 	)
 endif()

--- a/src/UI/CMakeLists.txt
+++ b/src/UI/CMakeLists.txt
@@ -14,15 +14,9 @@ target_compile_features(aether_ui PUBLIC cxx_std_20)
 set_target_properties(aether_ui
 	PROPERTIES
 	CXX_VISIBILITY_PRESET hidden
+	INTERPROCEDURAL_OPTIMIZATION "$<$<CONFIG:RELEASE>:TRUE:FALSE>"
 	PREFIX ""
 )
-
-if("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
-	set_target_properties(aether_ui
-		PROPERTIES
-		INTERPROCEDURAL_OPTIMIZATION TRUE
-	)
-endif()
 
 # Dependencies
 

--- a/src/UI/ui_tree.hpp
+++ b/src/UI/ui_tree.hpp
@@ -261,7 +261,7 @@ namespace Aether {
 		Circle(Root* root, CreateInfo create_info) noexcept :
 			UIElement(root, create_info) {}
 
-		virtual std::string name() const { return "Circle"; }
+		virtual std::string name() const override { return "Circle"; }
 	protected:
 
 		[[nodiscard]] float cx() const noexcept { return m_cx; }
@@ -284,7 +284,7 @@ namespace Aether {
 		Arc(Root* root, CreateInfo create_info) noexcept :
 			Circle(root, create_info) {}
 
-		virtual std::string name() const { return "Arc"; }
+		virtual std::string name() const override { return "Arc"; }
 	protected:
 
 		[[nodiscard]] float a0() const noexcept { return m_a0; }
@@ -307,7 +307,7 @@ namespace Aether {
 		Path(Root* root, CreateInfo create_info) noexcept :
 			UIElement(root, create_info) {}
 
-		virtual std::string name() const { return "Path"; }
+		virtual std::string name() const override { return "Path"; }
 
 		[[nodiscard]] std::string_view path() const;
 	protected:
@@ -326,7 +326,7 @@ namespace Aether {
 		Rect(Root* root, CreateInfo create_info) noexcept :
 			UIElement(root, create_info) {}
 
-		virtual std::string name() const { return "Rect"; }
+		virtual std::string name() const override { return "Rect"; }
 		/*
 			returns the position of the top left corner in pixels
 		*/
@@ -376,7 +376,7 @@ namespace Aether {
 			m_uniforms{create_info.uniform_infos}
 		{}
 
-		virtual std::string name() const { return "ShaderRect"; }
+		virtual std::string name() const override { return "ShaderRect"; }
 
 	protected:
 
@@ -412,7 +412,7 @@ namespace Aether {
 			Rect(root, create_info)
 		{}
 
-		virtual std::string name() const { return "Spectrum"; }
+		virtual std::string name() const override { return "Spectrum"; }
 	protected:
 
 		/*
@@ -430,7 +430,7 @@ namespace Aether {
 		Text(Root* root, CreateInfo create_info) noexcept :
 			Rect(root, create_info) {}
 
-		virtual std::string name() const { return "Text"; }
+		virtual std::string name()  const override { return "Text"; }
 	protected:
 
 		[[nodiscard]] std::string_view font_face() const;
@@ -498,7 +498,7 @@ namespace Aether {
 			}})
 		{}
 
-		virtual std::string name() const { return "Dial"; }
+		virtual std::string name() const override { return "Dial"; }
 	protected:
 		/*
 			Virtual functions
@@ -526,7 +526,7 @@ namespace Aether {
 		Group(Root* root, CreateInfo create_info) noexcept :
 			Rect(root, create_info) {}
 
-		virtual std::string name() const { return "Group"; }
+		virtual std::string name() const override { return "Group"; }
 
 		/*
 			modifiers


### PR DESCRIPTION
Doesn't compile out-of-the-box because I don't have LV2 API set up. This change allows for a self-contained build while still accepting user-specified LV2 API SDK via env var.