### PR TITLE
Fix lv2 syntax validation

### DIFF
--- a/resources/aether.ttl.in
+++ b/resources/aether.ttl.in
@@ -19,15 +19,17 @@
 	foaf:homepage <http://dougal-s.github.io>.
 
 <http://dougal-s.github.io#plugins>
-	a doap:project;
+	a doap:Project;
 	doap:maintainer <http://dougal-s.github.io>;
 	doap:name "Aether".
 
 <http://github.com/Dougal-s/Aether#input>
-	a pg:StereoGroup, pg:InputGroup.
+	a pg:StereoGroup, pg:InputGroup;
+	lv2:symbol "input".
 
 <http://github.com/Dougal-s/Aether#output>
 	a pg:StereoGroup, pg:OutputGroup;
+	lv2:symbol "output";
 	pg:source <http://github.com/Dougal-s/Aether#input>.
 
 <http://github.com/Dougal-s/Aether>
@@ -324,7 +326,7 @@
 		lv2:name "Late Order";
 		rdfs:comment "Controls the signal path in the late reverberation unit";
 		lv2:portProperty lv2:integer, lv2:enumeration;
-		lv2:scalePoints
+		lv2:scalePoint
 			[ rdfs:label "Pre"; rdf:value 0 ],
 			[ rdfs:label "Post"; rdf:value 1 ];
 		lv2:default 0;
@@ -597,7 +599,7 @@
 		lv2:default -12.0;
 		lv2:minimum -12.0;
 		lv2:maximum 12.0;
-		rdfs:scalePoints [
+		lv2:scalePoint [
 			rdfs:label "Off";
 			rdf:value -12.0
 		];


### PR DESCRIPTION
Please consider validating the ttl syntax, there were quite some issues with the main file:

```
error: Subject not in domain <http://usefulinc.com/ns/doap#Project>
       http://dougal-s.github.io#plugins
       http://usefulinc.com/ns/doap#maintainer
       http://dougal-s.github.io
error: Type is not a rdfs:Class or owl:Class
       http://dougal-s.github.io#plugins
       http://www.w3.org/1999/02/22-rdf-syntax-ns#type
       http://usefulinc.com/ns/doap#project
error: Object not in range <http://www.w3.org/2000/01/rdf-schema#Class>

       http://dougal-s.github.io#plugins
       http://www.w3.org/1999/02/22-rdf-syntax-ns#type
       http://usefulinc.com/ns/doap#project
error: Object not in range <http://usefulinc.com/ns/doap#Project>

       http://github.com/Dougal-s/Aether
       http://lv2plug.in/ns/lv2core#project
       http://dougal-s.github.io#plugins
error: Use of undefined property
       b774
       http://lv2plug.in/ns/lv2core#scalePoints
       b775
error: Property <http://lv2plug.in/ns/lv2core#scalePoints> has no label
       b774
       http://lv2plug.in/ns/lv2core#scalePoints
       b775
error: Use of undefined property
       b774
       http://lv2plug.in/ns/lv2core#scalePoints
       b776
error: Property <http://lv2plug.in/ns/lv2core#scalePoints> has no label
       b774
       http://lv2plug.in/ns/lv2core#scalePoints
       b776
error: Use of undefined property
       b802
       http://www.w3.org/2000/01/rdf-schema#scalePoints
       b803
error: Property <http://www.w3.org/2000/01/rdf-schema#scalePoints> has no label
       b802
       http://www.w3.org/2000/01/rdf-schema#scalePoints
       b803
error: Property http://lv2plug.in/ns/lv2core#symbol on http://github.com/Dougal-s/Aether#input has 0 != 1 values
       http://github.com/Dougal-s/Aether#input
       http://www.w3.org/1999/02/22-rdf-syntax-ns#type
       http://lv2plug.in/ns/ext/port-groups#StereoGroup
error: Property http://lv2plug.in/ns/lv2core#symbol on http://github.com/Dougal-s/Aether#output has 0 != 1 values
       http://github.com/Dougal-s/Aether#output
       http://www.w3.org/1999/02/22-rdf-syntax-ns#type
       http://lv2plug.in/ns/ext/port-groups#StereoGroup
error: Property http://lv2plug.in/ns/lv2core#symbol on http://github.com/Dougal-s/Aether#input has 0 != 1 values
       http://github.com/Dougal-s/Aether#input
       http://www.w3.org/1999/02/22-rdf-syntax-ns#type
       http://lv2plug.in/ns/ext/port-groups#InputGroup
error: Property http://lv2plug.in/ns/lv2core#symbol on http://github.com/Dougal-s/Aether#output has 0 != 1 values
       http://github.com/Dougal-s/Aether#output
       http://www.w3.org/1999/02/22-rdf-syntax-ns#type
       http://lv2plug.in/ns/ext/port-groups#OutputGroup
Found 14 errors among 87 files (checked 2538 restrictions)
```

This PR fixes all of those, for which then we get:

```
Found 0 errors among 87 files (checked 2540 restrictions)
```

See https://lv2plug.in/pages/validating-lv2-data.html for details on how to deal with that yourself.
Better yet, maybe make it part of CI steps
